### PR TITLE
Add grade entry button and statistics refresh

### DIFF
--- a/src/gui/KlausurverwaltungGUI.java
+++ b/src/gui/KlausurverwaltungGUI.java
@@ -103,9 +103,10 @@ public class KlausurverwaltungGUI extends Application {
         Button studentButton = createQuickActionButton("Studenten\nverwalten", e -> showStudentenVerwaltung());
         Button klausurButton = createQuickActionButton("Klausuren\nverwalten", e -> showKlausurenVerwaltung());
         Button anmeldungButton = createQuickActionButton("Anmeldungen\nverwalten", e -> showAnmeldungsVerwaltung());
+        Button notenButton = createQuickActionButton("Noten\neintragen", e -> showNotenVerwaltung());
         Button statistikButton = createQuickActionButton("Statistiken\nanzeigen", e -> showStatistiken());
-        
-        quickActions.getChildren().addAll(studentButton, klausurButton, anmeldungButton, statistikButton);
+
+        quickActions.getChildren().addAll(studentButton, klausurButton, anmeldungButton, notenButton, statistikButton);
         
         // Aktuelle Statistiken
         VBox stats = new VBox(10);
@@ -172,7 +173,7 @@ public class KlausurverwaltungGUI extends Application {
     }
 
     private void showNotenVerwaltung() {
-        NotenView view = new NotenView(studentenVerwaltung, klausurVerwaltung);
+        NotenView view = new NotenView(studentenVerwaltung, klausurVerwaltung, this::refreshStatistikenWennOffen);
         root.setCenter(view);
         updateStatus("Notenverwaltung geöffnet");
     }
@@ -188,7 +189,13 @@ public class KlausurverwaltungGUI extends Application {
         root.setCenter(view);
         updateStatus("Benachrichtigungen geöffnet");
     }
-    
+
+    private void refreshStatistikenWennOffen() {
+        if (root.getCenter() instanceof StatistikView) {
+            ((StatistikView) root.getCenter()).refresh();
+        }
+    }
+
     private void showAboutDialog() {
         Alert alert = new Alert(Alert.AlertType.INFORMATION);
         alert.setTitle("Über Klausurverwaltungssystem");

--- a/src/gui/views/NotenView.java
+++ b/src/gui/views/NotenView.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 public class NotenView extends BorderPane {
     private final ErweiterteStudentenVerwaltung studentenVerwaltung;
     private final KlausurVerwaltung klausurVerwaltung;
+    private final Runnable statistikUpdateCallback;
 
     private ComboBox<Student> studentComboBox;
     private ComboBox<Klausur> klausurComboBox;
@@ -22,9 +23,11 @@ public class NotenView extends BorderPane {
     private TableView<Versuch> versucheTable;
     private TextArea statusArea;
 
-    public NotenView(ErweiterteStudentenVerwaltung studentenVerwaltung, KlausurVerwaltung klausurVerwaltung) {
+    public NotenView(ErweiterteStudentenVerwaltung studentenVerwaltung, KlausurVerwaltung klausurVerwaltung,
+                     Runnable statistikUpdateCallback) {
         this.studentenVerwaltung = studentenVerwaltung;
         this.klausurVerwaltung = klausurVerwaltung;
+        this.statistikUpdateCallback = statistikUpdateCallback;
 
         setTop(createControlPanel());
         setCenter(createVersucheTable());
@@ -195,6 +198,9 @@ public class NotenView extends BorderPane {
                 student.getNachname(), klausur.getTitel()));
             noteField.clear();
             aktualisiereVersuchstabelle();
+            if (statistikUpdateCallback != null) {
+                statistikUpdateCallback.run();
+            }
         } catch (NumberFormatException ex) {
             showError("Ungültige Note. Bitte eine Zahl zwischen 1.0 und 5.0 eingeben.");
         } catch (Exception ex) {

--- a/src/gui/views/StatistikView.java
+++ b/src/gui/views/StatistikView.java
@@ -33,8 +33,21 @@ public class StatistikView extends BorderPane {
             createKlausurstatistikTab(),
             createLeistungsTab()
         );
-        
+
         setCenter(tabPane);
+    }
+
+    /**
+     * Aktualisiert alle Statistik-Tabs nach Datenänderungen
+     */
+    public void refresh() {
+        tabPane.getTabs().setAll(
+            createUebersichtTab(),
+            createNotenverteilungTab(),
+            createStudiengangTab(),
+            createKlausurstatistikTab(),
+            createLeistungsTab()
+        );
     }
     
     private Tab createUebersichtTab() {


### PR DESCRIPTION
## Summary
- Add "Noten eintragen" quick-action button to the welcome view for faster grade management
- Wire NotenView to refresh statistics after grade entry via callback in GUI
- Provide refresh method in StatistikView for automatic updates

## Testing
- `javac --module-path javafx/lib --add-modules javafx.controls,javafx.fxml -cp lib/sqlite-jdbc.jar:lib/slf4j-api.jar:lib/slf4j-simple.jar -d build @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_6890e9d648fc832dbcec5c7de6e117f6