### PR TITLE
Add student-grade entry button

### DIFF
--- a/src/gui/KlausurverwaltungGUI.java
+++ b/src/gui/KlausurverwaltungGUI.java
@@ -155,7 +155,7 @@ public class KlausurverwaltungGUI extends Application {
     }
     
     private void showStudentenVerwaltung() {
-        StudentenView view = new StudentenView(studentenVerwaltung);
+        StudentenView view = new StudentenView(studentenVerwaltung, this::showNotenVerwaltung);
         root.setCenter(view);
         updateStatus("Studentenverwaltung geöffnet");
     }
@@ -173,7 +173,11 @@ public class KlausurverwaltungGUI extends Application {
     }
 
     private void showNotenVerwaltung() {
-        NotenView view = new NotenView(studentenVerwaltung, klausurVerwaltung, this::refreshStatistikenWennOffen);
+        showNotenVerwaltung(null);
+    }
+
+    private void showNotenVerwaltung(Student student) {
+        NotenView view = new NotenView(studentenVerwaltung, klausurVerwaltung, this::refreshStatistikenWennOffen, student);
         root.setCenter(view);
         updateStatus("Notenverwaltung geöffnet");
     }

--- a/src/gui/views/NotenView.java
+++ b/src/gui/views/NotenView.java
@@ -25,6 +25,11 @@ public class NotenView extends BorderPane {
 
     public NotenView(ErweiterteStudentenVerwaltung studentenVerwaltung, KlausurVerwaltung klausurVerwaltung,
                      Runnable statistikUpdateCallback) {
+        this(studentenVerwaltung, klausurVerwaltung, statistikUpdateCallback, null);
+    }
+
+    public NotenView(ErweiterteStudentenVerwaltung studentenVerwaltung, KlausurVerwaltung klausurVerwaltung,
+                     Runnable statistikUpdateCallback, Student vorausgewaehlterStudent) {
         this.studentenVerwaltung = studentenVerwaltung;
         this.klausurVerwaltung = klausurVerwaltung;
         this.statistikUpdateCallback = statistikUpdateCallback;
@@ -34,6 +39,11 @@ public class NotenView extends BorderPane {
         setBottom(createStatusPanel());
 
         aktualisiereStudentenliste();
+        if (vorausgewaehlterStudent != null) {
+            studentComboBox.setValue(vorausgewaehlterStudent);
+            aktualisiereKlausurliste();
+            aktualisiereVersuchstabelle();
+        }
     }
 
     private VBox createControlPanel() {

--- a/src/gui/views/StudentenView.java
+++ b/src/gui/views/StudentenView.java
@@ -12,6 +12,7 @@ import verwaltung.ErweiterteStudentenVerwaltung.DuplikatException;
 import verwaltung.ErweiterteStudentenVerwaltung.ValidationResult;
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 public class StudentenView extends BorderPane {
     private ErweiterteStudentenVerwaltung verwaltung;
@@ -20,15 +21,17 @@ public class StudentenView extends BorderPane {
     private TextField suchfeld;
     private ComboBox<String> suchkriteriumBox;
     private Label statistikLabel;
-    
-    public StudentenView(ErweiterteStudentenVerwaltung verwaltung) {
+    private final Consumer<Student> notenHandler;
+
+    public StudentenView(ErweiterteStudentenVerwaltung verwaltung, Consumer<Student> notenHandler) {
         this.verwaltung = verwaltung;
+        this.notenHandler = notenHandler;
         this.studentenListe = FXCollections.observableArrayList();
-        
+
         setTop(createToolBar());
         setCenter(createTableView());
         setBottom(createStatistikBar());
-        
+
         aktualisiereListe();
     }
     
@@ -49,6 +52,14 @@ public class StudentenView extends BorderPane {
         
         Button loeschenButton = new Button("Löschen");
         loeschenButton.setOnAction(e -> studentLoeschen());
+
+        Button notenButton = new Button("Note eintragen");
+        notenButton.setOnAction(e -> {
+            Student selected = tableView.getSelectionModel().getSelectedItem();
+            if (selected != null && notenHandler != null) {
+                notenHandler.accept(selected);
+            }
+        });
         
         // Suche
         suchfeld = new TextField();
@@ -64,7 +75,7 @@ public class StudentenView extends BorderPane {
         aktualisierenButton.setOnAction(e -> aktualisiereListe());
         
         toolBar.getItems().addAll(
-            neuButton, bearbeitenButton, loeschenButton,
+            neuButton, bearbeitenButton, loeschenButton, notenButton,
             new Separator(),
             new Label("Suche:"), suchkriteriumBox, suchfeld,
             new Separator(),


### PR DESCRIPTION
## Summary
- allow entering a grade for a selected student directly from the student management view
- support preselecting a student in the grade entry view to streamline grade input
- wire GUI to open the grade entry view with a selected student and update statistics automatically

## Testing
- `javac --module-path javafx/lib --add-modules javafx.controls,javafx.fxml -cp lib/sqlite-jdbc.jar:lib/slf4j-api.jar:lib/slf4j-simple.jar -d out @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_6890ef446910832daa5dcff4da9d4f13