### PR TITLE
Ensure grade entry button appears

### DIFF
--- a/run-gui.bat
+++ b/run-gui.bat
@@ -1,3 +1,7 @@
 @echo off
+rem Compile sources so the latest GUI features are available
+javac --module-path javafx/lib --add-modules javafx.controls,javafx.fxml -cp ".;lib/sqlite-jdbc.jar;lib/slf4j-api.jar;lib/slf4j-simple.jar" -d . src\util\Database.java src\verwaltung\*.java src\model\*.java src\gui\*.java src\gui\views\*.java
+
+rem Start the application
 java --module-path javafx/lib --add-modules javafx.controls,javafx.fxml -cp ".;lib/sqlite-jdbc.jar;lib/slf4j-api.jar;lib/slf4j-simple.jar" gui.KlausurverwaltungGUI
 pause


### PR DESCRIPTION
## Summary
- Compile all Java sources before launching the GUI so new views like the grade-entry screen are included.

## Testing
- `javac --module-path javafx/lib --add-modules javafx.controls,javafx.fxml -cp ".:lib/sqlite-jdbc.jar:lib/slf4j-api.jar:lib/slf4j-simple.jar" -d . src/util/Database.java src/verwaltung/*.java src/model/*.java src/gui/*.java src/gui/views/*.java`


------
https://chatgpt.com/codex/tasks/task_e_6890f19d5bcc832d9ca00c4213d64404